### PR TITLE
Disable futures

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -70,3 +70,5 @@ collections:
     layout: bestof
 
 exclude: [vendor]
+
+future: false #do not allow posts from the future to be published...


### PR DESCRIPTION
Apparently Jekyll automatically publishes posts from the future

Example: http://www.valentinourbano.com/The-Road-To-Publish-My-Short-ebook.html